### PR TITLE
Improve Developer Experience

### DIFF
--- a/contracts/MyDapp.sol
+++ b/contracts/MyDapp.sol
@@ -2,7 +2,7 @@ pragma solidity >=0.4.21 <0.6.0;
 
 import "truffle/TruffleLogger.sol";
 
-contract MyDapp is TruffleLogger {
+contract MyDapp {
   bool myBool = true;
   int myInt = -4321;
   uint myUint = 1234;

--- a/test/TestMyDapp.sol
+++ b/test/TestMyDapp.sol
@@ -1,0 +1,11 @@
+pragma solidity >=0.4.25 <0.7.0;
+
+import "truffle/TruffleLogger.sol";
+
+contract TestLogger {
+
+  function testLogger() public {
+    string memory myString = "myString";
+    TruffleLogger.log(myString);
+  }
+}


### PR DESCRIPTION
Now all the user needs to do is `import` and call `TruffleLogger.log(myVar)`:

```
import "truffle/TruffleLogger.sol";	

contract MyDapp {

  function doSomething() public {
    TruffleLogger.log(myVar);
  }
}
```

### Changes

- Logger is a library instead of a contract
  - **You no longer have to inherit to use it**, you only need to import
- Solidity test example added