### PR TITLE
Rename TruffleLogger to Console

### DIFF
--- a/contracts/MyDapp.sol
+++ b/contracts/MyDapp.sol
@@ -1,6 +1,6 @@
 pragma solidity >=0.4.21 <0.6.0;
 
-import "truffle/TruffleLogger.sol";
+import "truffle/Console.sol";
 
 contract MyDapp {
   bool myBool = true;
@@ -11,11 +11,11 @@ contract MyDapp {
   address myAddress = address(this);
 
   function doSomething() public {
-    TruffleLogger.log(myBool);
-    TruffleLogger.log(myInt);
-    TruffleLogger.log(myUint);
-    TruffleLogger.log(myString);
-    TruffleLogger.log(myBytes32);
-    TruffleLogger.log(myAddress);
+    Console.log(myBool);
+    Console.log(myInt);
+    Console.log(myUint);
+    Console.log(myString);
+    Console.log(myBytes32);
+    Console.log(myAddress);
   }
 }

--- a/test/TestMyDapp.sol
+++ b/test/TestMyDapp.sol
@@ -1,11 +1,11 @@
 pragma solidity >=0.4.25 <0.7.0;
 
-import "truffle/TruffleLogger.sol";
+import "truffle/Console.sol";
 
 contract TestLogger {
 
   function testLogger() public {
     string memory myString = "myString";
-    TruffleLogger.log(myString);
+    Console.log(myString);
   }
 }


### PR DESCRIPTION
I hope I didn't miss any re-namings here, but basically this makes it so that usage requires Truffle.log rather than TruffleLogger.log.

This can be merged after this PR is merged: https://github.com/trufflesuite/truffle/pull/2707